### PR TITLE
upgrade node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ slack-fail-post-step: &slack-fail-post-step
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.9.1
+    - image: cimg/node:18.16.0
 
 orbs:
   slack: circleci/slack@4.4.2


### PR DESCRIPTION
Sorry, let me consult with you.
I'm not familiar with circleci settings.
Bulding js sdk failed by uinsing webpack.
I got syntax error.

https://app.circleci.com/pipelines/github/hexabase/hexabase-js/178/workflows/036cc84f-fbdd-4cbd-870e-ff7fdb4615ee/jobs/36/parallel-runs/0/steps/0-105

So I checked node version.
I think node version is old.
So I'd like to upgrade node version by using cimg.
Is it good way to use cimg node?