### PR TITLE
Add as_params to execute

### DIFF
--- a/src/lib/packages/item/index.ts
+++ b/src/lib/packages/item/index.ts
@@ -445,11 +445,7 @@ export default class Item extends HxbAbstract {
     return true;
   }
 
-  async execute(actionName: string, {
-    params
-  }: {
-    params?: any;
-  } = {}): Promise<boolean> {
+  async execute(actionName: string, params: any = undefined): Promise<boolean> {
     const action = await this.actionOrStatusAction(actionName);
     if (!action) throw new Error(`Action ${actionName} not found`);
     const payload: ItemActionParameters = {
@@ -470,6 +466,7 @@ export default class Item extends HxbAbstract {
       projectId: this.datastore.project.id,
       itemActionParameters: payload
     });
+    console.log(res);
     // this.sets(res.datastoreExecuteItemAction.item);
     // this._setStatus(this._status);
     await this.fetch();

--- a/src/lib/packages/item/item.test.ts
+++ b/src/lib/packages/item/item.test.ts
@@ -180,6 +180,14 @@ describe('Item', () => {
       expect(item.status).toBe(item2.status);
       await item.delete();
     });
+
+    it('should execute action with as_params', async () => {
+      jest.useFakeTimers('legacy');
+      const { datastore } = params;
+      const item = await datastore!.item();
+      await item.save();
+      const res = await item.execute('ExecuteActionScript', {test: 'test'});
+    });
   });
 });
 


### PR DESCRIPTION
## Usage

```js
await item.execute('ExecuteActionScript', {test: 'test'});
```

When it executes above code, we can get parameters like below.

```js
async function main (data) {
    logger.info(data.as_params); // {test: 'test'}
}
```