### PR TITLE
Execute lookup_items later

### DIFF
--- a/src/lib/packages/item/index.ts
+++ b/src/lib/packages/item/index.ts
@@ -391,7 +391,13 @@ export default class Item extends HxbAbstract {
     await datastore.project.datastores();
     // await Promise.all(datastores.map(d => d.fields()));
     const items = res.itemWithSearch.items
-      .map(params => Item.fromJson({ ...{ datastore }, ...params }) as Item);
+      .map(params => {
+        const item = Item.fromJson({ ...{ datastore }, ...params }) as Item;
+        if (params.lookup_items) {
+          item.set('lookup_items', params.lookup_items);
+        }
+        return item;
+      });
     const totalCount = res.itemWithSearch.totalItems;
     if (options.deep) {
       await Promise.all(items.map(item => item.fetch()));

--- a/src/lib/packages/item/item.test.ts
+++ b/src/lib/packages/item/item.test.ts
@@ -46,7 +46,7 @@ describe('Item', () => {
       const [item] = await query
         .from(datastore!.id)
         .where(query.condition.equalTo('test_text_unique', 'テストテキストユニーク'))
-        .select('*', {deep: true});
+        .select('*');
       expect(item.get('test_dslookup') instanceof Item).toBe(true);
     });
   });


### PR DESCRIPTION
The lookup_items got an advantage than a normal key.

```js
const query = client.query(project!.id);
const [item] = await query
  .from(datastore!.id)
  .where(query.condition.equalTo('test_text_unique', 'テストテキストユニーク'))
  .select('*');
expect(item.get('test_dslookup') instanceof Item).toBe(true);
```